### PR TITLE
mailparser updated to version 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Parse eml file and output html",
   "main": "parse.js",
   "dependencies": {
-    "mailparser": "^0.4.6",
+    "mailparser": "^0.6.2",
     "nomnom": "^1.8.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
As commented in issue #1, updating `mailparser` to the version 0.6.2 solves the problem related to the mentioned dependency.

Version number has been changed on _package.json_ for `mailparser` so that it'll be downloaded in this specific version when you download all npm dependencies with `npm install`.